### PR TITLE
Adding posit::conf(2023)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "events-positconf2023"]
+	path = events-positconf2023
+	url = https://github.com/pharmar/events-positconf2023
+[submodule "positconf2023"]
+	path = positconf2023
+	url = https://github.com/pharmar/events-positconf2023

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "events-positconf2023"]
-	path = events-positconf2023
-	url = https://github.com/pharmar/events-positconf2023
 [submodule "positconf2023"]
 	path = positconf2023
 	url = https://github.com/pharmar/events-positconf2023


### PR DESCRIPTION
Taking a bit of a different tack with these slides.

I added them as a submodule because I want to be able to [host the slides in their own github pages page](https://pharmar.github.io/events-positconf2023/#/title-slide) as a separate repository. 

To continue keeping this repo as a catalog of past presentations, I'm including it as a submodule so that it can still be pulled with all the other past contents even though it lives in a standalone repo.
